### PR TITLE
Support es5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 script: npm run test-ci
 node_js:
+  - "0.12"
   - 4

--- a/index.js
+++ b/index.js
@@ -3,18 +3,18 @@ var path = require('path')
 
 var MAP_KEY = '__public_loader_map__'
 
-module.exports = function(content)  {
-  const originEmitFile = this.emitFile
-  const map = this._compilation[MAP_KEY] = this._compilation[MAP_KEY] || {}
+module.exports = function (content) {
+  var originEmitFile = this.emitFile
+  var map = this._compilation[MAP_KEY] = this._compilation[MAP_KEY] || {}
 
   // Override emitFile function to get an url from file-loader
-  this.emitFile = (url, fileContent) => {
+  this.emitFile = function(url, fileContent) {
     map[this.resource] = path.join(this.options.output.publicPath || '/', url)
     originEmitFile.call(this, url, fileContent)
-  }
+  }.bind(this)
 
   // Call file-loader and store the result
-  const result = fileLoader.call(this, content)
+  var result = fileLoader.call(this, content)
 
   // Restore emitFile function
   this.emitFile = originEmitFile

--- a/test/integration.js
+++ b/test/integration.js
@@ -15,7 +15,7 @@ describe('integration tests', function() {
     rmrf(path.join(__dirname, 'dist'), done)
   })
 
-  context('when publicPath is specified', () => {
+  context('when publicPath is specified', function() {
     it('stores files map in the compilation stats', function(done) {
       var compiler = webpack({
         context: __dirname,
@@ -34,7 +34,7 @@ describe('integration tests', function() {
           path.join(__dirname, 'fixtures', 'public', 'b.gif'),
           path.join(__dirname, 'fixtures', 'public', 'c.gif')
         ])
-        fileNames.forEach((fileName) => {
+        fileNames.forEach(function(fileName) {
           assert(publicFiles[fileName].match(/\/bundles\/\w+.gif$/))
         })
         done()
@@ -42,7 +42,7 @@ describe('integration tests', function() {
     })
   })
 
-  context('when publicPath is not specified', () => {
+  context('when publicPath is not specified', function() {
     it('stores files map in the compilation stats', function(done) {
       var compiler = webpack({
         context: __dirname,
@@ -60,7 +60,7 @@ describe('integration tests', function() {
           path.join(__dirname, 'fixtures', 'public', 'b.gif'),
           path.join(__dirname, 'fixtures', 'public', 'c.gif')
         ])
-        fileNames.forEach((fileName) => {
+        fileNames.forEach(function(fileName) {
           assert(publicFiles[fileName].match(/\/\w+.gif$/))
         })
         done()


### PR DESCRIPTION
A lot of people still use Node JS 0.12 and are not able to use the harmony flags, so I think it would make sense to support these environments by only using es5 features.
