### PR TITLE
Update file-loader to 0.11.2 to fix loader-utils deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 script: npm run test-ci
 node_js:
-  - "0.12"
   - 4
+  - 6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Improvements:
+  - Updated file-loader to 0.11.2
+
 ## v0.4.0 (13 Jan 2016)
 
 * Improvements:

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   },
   "homepage": "https://github.com/kossnocorp/static-file-loader",
   "peerDependencies": {
-    "file-loader": "^0.8.4"
+    "file-loader": "^0.11.2"
   },
   "devDependencies": {
     "espower-loader": "^1.0.0",
-    "file-loader": "^0.8.4",
+    "file-loader": "^0.11.2",
     "mocha": "kossnocorp/mocha#c62939",
     "power-assert": "^1.1.0",
     "rewire": "^2.3.4",


### PR DESCRIPTION
Using static-file-loader@0.4.0 with file-loader@0.8.5 and Webpack 2 results in the following warning:
```
DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
```

In order to avoid this warning in my project, I need to update file-loader to >=0.10.1: https://github.com/webpack-contrib/file-loader/commit/5d8f73ebe73fbff0f0dea2d57a01c9b2c69198c9

I confirmed that updating this in my project gets rid of the warnings (but introduces npm errors because of the peer dependency incompatibility).

Since file-loader has an explicit peerDependency on file-loader ^0.8.4, I need this to change here.

file-loader@0.11.2 doesn't support Node 0.12, and official support for [Node@0.12 ended in 2016](https://nodejs.org/en/blog/release/v0.12.13/). I removed Node@0.12 from the `.travis.yml` and added Node 6 for good measure. Let me know if this is a problem.